### PR TITLE
octeon: bring up target itusrouter

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -8,6 +8,9 @@
 board_config_update
 
 case "$(board_name)" in
+itus_shield-router)
+	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
+	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	;;

--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -3,23 +3,27 @@ do_sysinfo_octeon() {
 	local name
 
 	machine=$(grep "^system type" /proc/cpuinfo | sed "s/system type.*: \(.*\)/\1/g")
+	smode=$(do_get_shield_mode)
 
 	case "$machine" in
 	"UBNT_E100"*)
-		name="erlite"
-		;;
+	      name="erlite"
+	      ;;
 
 	"UBNT_E200"*)
-		name="er"
-		;;
+	      name="er"
+	      ;;
 
 	"UBNT_E220"*)
-		name="erpro"
-		;;
+	      name="erpro"
+	      ;;
 
+	"ITUS_SHIELD"*)
+	      name="itus_shield-router"
+	      ;;
 	*)
-		name="generic"
-		;;
+	      name="generic"
+	      ;;
 	esac
 
 	[ -e "/tmp/sysinfo/" ] || mkdir -p "/tmp/sysinfo/"
@@ -27,5 +31,4 @@ do_sysinfo_octeon() {
 	echo "$name" > /tmp/sysinfo/board_name
 	echo "$machine" > /tmp/sysinfo/model
 }
-
 boot_hook_add preinit_main do_sysinfo_octeon

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -10,6 +10,11 @@ move_config() {
 			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
 			umount /mnt
 			;;
+		itus_shield-router)
+			mount -t vfat /dev/mmcblk1p1 /mnt
+			[ -f "/mnt/$BACKUP_FILE-$(board_name)" ] && mv -f "/mnt/$BACKUP_FILE" /
+			umount /mnt
+			;;
 	esac
 }
 

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2014 OpenWrt.org
 #
+RAMFS_COPY_BIN=mkfs.f2fs
 
 platform_get_rootfs() {
 	local rootfsdev
@@ -28,6 +29,12 @@ platform_copy_config() {
 		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
 		umount /mnt
 		;;
+	itus_shield-router)
+		mount -t vfat /dev/mmcblk1p1 /mnt
+		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
+		umount /mnt
+			;;
+		;;
 	esac
 }
 
@@ -38,20 +45,34 @@ platform_do_flash() {
 	local rootfs=$4
 
 	mkdir -p /boot
-	mount -t vfat /dev/$kernel /boot
 
-	[ -f /boot/vmlinux.64 -a ! -L /boot/vmlinux.64 ] && {
+	if [ $board == "itus_shield-router" ]; then
+	   # mmcblk1p1 (fat) contains all ELF-bin images for the Shield
+	   mount /dev/mmcblk1p1 /boot
+	   echo "flashing Itus Kernel to /boot/$kernel (/dev/mmblk1p1)"
+	   tar -C /tmp -xvf $tar_file
+	   cp /tmp/sysupgrade-$board/kernel /boot/$kernel
+	   umount /boot
+	   echo "flashing rootfs to ${rootfs}"
+	   dd if=/tmp/sysupgrade-$board/root of="${rootfs}"
+	else
+	   echo "flashing kernel to /dev/$kernel"
+	   mount -t vfat /dev/$kernel /boot
+
+	   [ -f /boot/vmlinux.64 -a ! -L /boot/vmlinux.64 ] && {
 		mv /boot/vmlinux.64 /boot/vmlinux.64.previous
 		mv /boot/vmlinux.64.md5 /boot/vmlinux.64.md5.previous
-	}
+	   }
 
-	echo "flashing kernel to /dev/$kernel"
-	tar xf $tar_file sysupgrade-$board/kernel -O > /boot/vmlinux.64
-	md5sum /boot/vmlinux.64 | cut -f1 -d " " > /boot/vmlinux.64.md5
-	echo "flashing rootfs to ${rootfs}"
-	tar xf $tar_file sysupgrade-$board/root -O | dd of="${rootfs}" bs=4096
+	   echo "flashing kernel to /dev/$kernel"
+	   tar xf $tar_file sysupgrade-$board/kernel -O > /boot/vmlinux.64
+	   md5sum /boot/vmlinux.64 | cut -f1 -d " " > /boot/vmlinux.64.md5
+	   umount /boot
+
+	   echo "flashing rootfs to ${rootfs}"
+	   tar xvf $tar_file sysupgrade-$board/root -O | dd of="${rootfs}" bs=4096
+	fi
 	sync
-	umount /boot
 }
 
 platform_do_upgrade() {
@@ -68,6 +89,9 @@ platform_do_upgrade() {
 	erlite)
 		kernel=sda1
 		;;
+	itus_shield-router)
+		kernel=ItusrouterImage
+		;;
 	*)
 		return 1
 	esac
@@ -75,7 +99,7 @@ platform_do_upgrade() {
 	platform_do_flash $tar_file $board $kernel $rootfs
 
 	return 0
-	
+
 }
 
 platform_check_image() {
@@ -83,7 +107,8 @@ platform_check_image() {
 
 	case "$board" in
 	er | \
-	erlite)
+	erlite | \
+	itus_shield-router)
 		local tar_file="$1"
 		local kernel_length=$(tar xf $tar_file sysupgrade-$board/kernel -O | wc -c 2> /dev/null)
 		local rootfs_length=$(tar xf $tar_file sysupgrade-$board/root -O | wc -c 2> /dev/null)

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -47,4 +47,15 @@ define Device/ubnt_edgerouter-lite
 endef
 TARGET_DEVICES += ubnt_edgerouter-lite
 
+ITUSROUTER_CMDLINE:=console=ttyS0,115200, root=/dev/mmcblk1p2 rootfstype=squashfs,ext4,f2fs rootwait
+define Device/itus_shield-router
+  DEVICE_VENDOR := Itus Networks
+  DEVICE_MODEL := Shield Router
+  BOARD_NAME := itus_shield-router
+  CMDLINE := $(ITUSROUTER_CMDLINE)
+  IMAGE/sysupgrade.tar/squashfs :+ append-metadata | combined-image
+  CPU_TYPE := octeon3
+endef
+TARGET_DEVICES += itus_shield-router
+
 $(eval $(call BuildImage))

--- a/target/linux/octeon/patches-5.4/130-itus_shield_support.patch
+++ b/target/linux/octeon/patches-5.4/130-itus_shield_support.patch
@@ -1,0 +1,42 @@
+--- a/arch/mips/include/asm/octeon/cvmx-bootinfo.h
++++ b/arch/mips/include/asm/octeon/cvmx-bootinfo.h
+@@ -297,7 +297,7 @@ enum cvmx_board_types_enum {
+ 	CVMX_BOARD_TYPE_UBNT_E100 = 20002,
+ 	CVMX_BOARD_TYPE_UBNT_E200 = 20003,
+ 	CVMX_BOARD_TYPE_UBNT_E220 = 20005,
+-	CVMX_BOARD_TYPE_CUST_DSR1000N = 20006,
++	CVMX_BOARD_TYPE_ITUS_SHIELD = 20006,
+ 	CVMX_BOARD_TYPE_KONTRON_S1901 = 21901,
+ 	CVMX_BOARD_TYPE_CUST_PRIVATE_MAX = 30000,
+ 
+@@ -400,7 +400,7 @@ static inline const char *cvmx_board_typ
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E100)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E200)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E220)
+-		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_CUST_DSR1000N)
++		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_ITUS_SHIELD)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_KONTRON_S1901)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_CUST_PRIVATE_MAX)
+ 	}
+--- a/arch/mips/cavium-octeon/octeon-platform.c
++++ b/arch/mips/cavium-octeon/octeon-platform.c
+@@ -707,7 +707,7 @@ int __init octeon_prune_device_tree(void
+ 	if (fdt_check_header(initial_boot_params))
+ 		panic("Corrupt Device Tree.");
+ 
+-	WARN(octeon_bootinfo->board_type == CVMX_BOARD_TYPE_CUST_DSR1000N,
++	WARN(octeon_bootinfo->board_type == CVMX_BOARD_TYPE_ITUS_SHIELD,
+ 	     "Built-in DTB booting is deprecated on %s. Please switch to use appended DTB.",
+ 	     cvmx_board_type_to_string(octeon_bootinfo->board_type));
+ 
+--- a/arch/mips/pci/pci-octeon.c
++++ b/arch/mips/pci/pci-octeon.c
+@@ -211,7 +211,7 @@ const char *octeon_get_pci_interrupts(vo
+ 		return "AAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+ 	case CVMX_BOARD_TYPE_BBGW_REF:
+ 		return "AABCD";
+-	case CVMX_BOARD_TYPE_CUST_DSR1000N:
++	case CVMX_BOARD_TYPE_ITUS_SHIELD:
+ 		return "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+ 	case CVMX_BOARD_TYPE_THUNDER:
+ 	case CVMX_BOARD_TYPE_EBH3000:


### PR DESCRIPTION
Itus Networks Shield - 1Ghz dual-core mips64 / Cavium Octeon 3 SoC, 1Gb RAM, 4Gb eMMC,3 GbE 10/100/1000 ports

Information regarding device can be found: https://deviwiki.com/wiki/Itus_Networks_Shield_Pro

Installing OpenWrt on Itus Networks Shield:
This firmware only makes use of the ROUTER image slot.

1) Boot into the device
2) On device: mount /dev/mmcblk1p1 /mnt
3) scp openwrt-octeon-itus_shield-router-initramfs-kernel.bin to /mnt/ItusrouterImage
4) On device: umount /mnt
5) Ensure the front-panel switch is in the (R)outer setting, then reboot

Post-flash instructions:
1) Boot into the device
2) Create the filesystem: mkfs.f2fs /dev/mmcblk1p2
3) Flash the openwrt-octeon-itus_shield-router-squashfs-sysupgrade.tar file via cli or luCi.

Once rebooted, the system installation is complete.

Signed-off-by: Donald Hoskins <grommish@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
